### PR TITLE
Use TLS 1.2 in Powershell script

### DIFF
--- a/removeTokens.ps1
+++ b/removeTokens.ps1
@@ -33,6 +33,7 @@ add-type @"
 $bodyContent = ConvertTo-Json -Compress @{ "challengeIds" = @() }
 
 # Send the request
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 $response = Invoke-RestMethod -Uri $URL -Headers $headers -Method Post -Body $bodyContent -ContentType "application/json"
 
 # Output the response


### PR DESCRIPTION
Powershell by default uses TLS 1.0 so it gets "Invoke-RestMethod : The request was aborted: Could not create SSL/TLS secure channel." when doing request. Update to use TLS 1.2 to solve this issue.