### PR TITLE
Possible macOS support?

### DIFF
--- a/removetokens.sh
+++ b/removetokens.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-pid=$(pidof "LeagueClientUx.exe")
-# these are null separated but cat -v replaces null characters with ^@
-cmdline=$(cat -v /proc/$pid/cmdline)
-port=$(echo $cmdline | sed -n -e 's/.*--app-port=\([0-9]*\)^@.*/\1/p')
-token=$(echo $cmdline | sed -n -e 's/.*--remoting-auth-token=\([a-zA-Z0-9]*\)^@.*/\1/p')
+cmdline=$(ps -ax | grep LeagueClientUx.exe)
+port=$(echo $cmdline | sed -n 's/.*--app-port=\([0-9]*\).*/\1/p')
+token=$(echo $cmdline | sed -n 's/.*--remoting-auth-token=\(\S*\).*/\1/p')
 auth=$(echo -n "riot:$token" | base64)
 
 # you might need to close your client without touching anything after this.


### PR DESCRIPTION
Tested on Linux, works fine. **macOS is untested.** It looks like by default macOS doesn't include `pidof`, so this uses `ps -ax` to get the command line arguments instead. If macOS's shell includes `base64`, this will probably work without changes.