### PR TITLE
Add macOS support, tested on 14.2.1

### DIFF
--- a/removetokensMacOS.sh
+++ b/removetokensMacOS.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cmdline=$(ps ax | grep '[L]eagueClientUx --riotclient-auth-token' | grep -v grep)
+
+port=$(echo "$cmdline" | sed -n 's/.*--app-port=\([0-9]*\).*/\1/p')
+token=$(echo "$cmdline" | sed -n 's/.*--remoting-auth-token=\([^ ]*\).*/\1/p')
+auth=$(echo -n "riot:$token" | base64)
+
+# you might need to close your client without touching anything after this.
+curl --insecure --request POST -H "Authorization: Basic $auth" -H "Content-type: application/json" -d '{"challengeIds":[]}' "https://127.0.0.1:$port/lol-challenges/v1/update-player-preferences"


### PR DESCRIPTION
## Overview
This pull request introduces changes to the existing LeagueClientUx script to ensure it works seamlessly on macOS. Previously, the script was designed for Linux environments, utilizing specific system calls and options that are not compatible with macOS.

## Changes Made
- Modified the grep pattern to accurately locate the LeagueClientUx process in macOS.
- Adjusted the sed command to extract the necessary `port` and `remoting-auth-token` from the process's command line arguments, which are formatted differently on macOS.